### PR TITLE
feat: Implement Bookmark Screen with ViewModel and State

### DIFF
--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/bookmark/BookmarkScreen.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/bookmark/BookmarkScreen.kt
@@ -1,12 +1,74 @@
 package com.repleyva.gamexapp.presentation.screens.bookmark
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import com.repleyva.gamexapp.R
+import com.repleyva.gamexapp.presentation.components.LaunchEffectOnce
+import com.repleyva.gamexapp.presentation.screens.bookmark.BookmarkScreenEvent.Init
+import com.repleyva.gamexapp.presentation.screens.bookmark.BookmarkScreenEvent.NavigateToDetailScreen
+import com.repleyva.gamexapp.presentation.screens.home.components.GameItem
+import com.repleyva.gamexapp.presentation.ui.theme.Neutral50
+import com.repleyva.gamexapp.presentation.ui.theme.Primary50
 
 @Destination
 @Composable
 fun BookmarkScreen(
     navigator: DestinationsNavigator,
+    viewModel: BookmarkViewModel = hiltViewModel(),
 ) {
+
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        contentPadding = PaddingValues(vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+
+        item {
+            Text(
+                text = stringResource(id = R.string.title_bookmark),
+                style = MaterialTheme.typography.headlineMedium,
+                color = Primary50
+            )
+            Text(
+                text = stringResource(id = R.string.label_bookmark_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = Neutral50
+            )
+        }
+
+        if (state.games.isNotEmpty()) {
+            items(items = state.games, key = { it.id }) {
+                GameItem(
+                    game = it,
+                    onEvent = { game ->
+                        viewModel.eventHandler(NavigateToDetailScreen(game))
+                    }
+                )
+            }
+        }
+    }
+
+    LaunchEffectOnce {
+        viewModel.eventHandler(Init(navigator))
+    }
+
 }

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/bookmark/BookmarkScreenEvent.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/bookmark/BookmarkScreenEvent.kt
@@ -1,0 +1,12 @@
+package com.repleyva.gamexapp.presentation.screens.bookmark
+
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import com.repleyva.core.domain.model.Game
+import com.repleyva.gamexapp.presentation.base.Event
+
+sealed interface BookmarkScreenEvent : Event {
+
+    data class Init(val navigation: DestinationsNavigator) : BookmarkScreenEvent
+
+    data class NavigateToDetailScreen(val game: Game) : BookmarkScreenEvent
+}

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/bookmark/BookmarkScreenState.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/bookmark/BookmarkScreenState.kt
@@ -1,0 +1,8 @@
+package com.repleyva.gamexapp.presentation.screens.bookmark
+
+import com.repleyva.core.domain.model.Game
+import com.repleyva.gamexapp.presentation.base.State
+
+data class BookmarkScreenState(
+    val games: List<Game> = emptyList(),
+) : State

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/bookmark/BookmarkViewModel.kt
@@ -1,0 +1,51 @@
+package com.repleyva.gamexapp.presentation.screens.bookmark
+
+import androidx.lifecycle.viewModelScope
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import com.repleyva.core.domain.model.Game
+import com.repleyva.core.domain.use_cases.GameUseCase
+import com.repleyva.gamexapp.presentation.base.SimpleMVIBaseViewModel
+import com.repleyva.gamexapp.presentation.screens.bookmark.BookmarkScreenEvent.Init
+import com.repleyva.gamexapp.presentation.screens.bookmark.BookmarkScreenEvent.NavigateToDetailScreen
+import com.repleyva.gamexapp.presentation.screens.destinations.DetailScreenDestination
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BookmarkViewModel @Inject constructor(
+    private val gameUseCase: GameUseCase,
+) : SimpleMVIBaseViewModel<BookmarkScreenState, BookmarkScreenEvent>() {
+
+    private var navigator: DestinationsNavigator? = null
+
+    override fun initState(): BookmarkScreenState = BookmarkScreenState()
+
+    override fun eventHandler(event: BookmarkScreenEvent) {
+        when (event) {
+            is Init -> init(event.navigation)
+            is NavigateToDetailScreen -> navigateToDetailScreen(event.game)
+        }
+    }
+
+    private fun init(navigator: DestinationsNavigator) {
+        this.navigator = navigator
+        getBookmarkedGames()
+    }
+
+    private fun getBookmarkedGames() {
+        viewModelScope.launch(Dispatchers.IO) {
+            gameUseCase.getBookmarkedGames().onEach { games ->
+                updateUi { copy(games = games) }
+            }.launchIn(viewModelScope)
+        }
+    }
+
+    private fun navigateToDetailScreen(game: Game) {
+        navigator?.navigate(DetailScreenDestination(game))
+    }
+
+}


### PR DESCRIPTION
This commit introduces the Bookmark Screen feature, including the necessary components for managing and displaying bookmarked games:

-   Created `BookmarkViewModel` to handle the business logic, state, and events related to the bookmark screen.
-   Implemented `BookmarkScreenState` to represent the UI state for the screen, including a list of bookmarked games.
-   Defined `BookmarkScreenEvent` to handle user interactions and lifecycle events on the bookmark screen.
-   Added `BookmarkScreen` composable function to display the list of bookmarked games and navigate to the detail screen when a game is clicked.
-   The screen displays a title and description, and a list of bookmarked game items.
-   The screen loads bookmarked games upon initialization using `gameUseCase.getBookmarkedGames()`
-   The screen navigates to the detail screen when a game item is clicked.