### PR TITLE
feat: Add detail screen

### DIFF
--- a/app/src/main/java/com/repleyva/gamexapp/presentation/extensions/ContextExtensions.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/extensions/ContextExtensions.kt
@@ -1,0 +1,18 @@
+package com.repleyva.gamexapp.presentation.extensions
+
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+
+fun Context.showToast(message: String) {
+    Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+}
+
+fun Context.shareLink(url: String) {
+    val shareIntent = Intent().apply {
+        action = Intent.ACTION_SEND
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, url)
+    }
+    startActivity(Intent.createChooser(shareIntent, null))
+}

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/DetailScreen.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/DetailScreen.kt
@@ -1,14 +1,231 @@
 package com.repleyva.gamexapp.presentation.screens.detail
 
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.repleyva.core.domain.model.Game
+import com.repleyva.gamexapp.R
+import com.repleyva.gamexapp.presentation.components.Gap
+import com.repleyva.gamexapp.presentation.components.LaunchEffectOnce
+import com.repleyva.gamexapp.presentation.extensions.shareLink
+import com.repleyva.gamexapp.presentation.extensions.shimmerEffect
+import com.repleyva.gamexapp.presentation.extensions.showToast
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.BookmarkGame
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.Init
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.ShareGame
+import com.repleyva.gamexapp.presentation.screens.detail.components.GamePoster
+import com.repleyva.gamexapp.presentation.screens.detail.components.GeneralGameInfo
+import com.repleyva.gamexapp.presentation.screens.detail.components.Screenshots
+import com.repleyva.gamexapp.presentation.screens.home.components.TagGroup
+import com.repleyva.gamexapp.presentation.ui.theme.Neutral40
+import com.repleyva.gamexapp.presentation.ui.theme.Neutral50
+import com.repleyva.gamexapp.presentation.ui.theme.Primary70
 
 @Destination
 @Composable
 fun DetailScreen(
     game: Game,
     navigator: DestinationsNavigator,
+    viewModel: DetailViewModel = hiltViewModel(),
 ) {
+
+    val context = LocalContext.current
+
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val savedState = rememberSaveable { mutableStateOf(game.isFavorites) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+    ) {
+        state.game?.let { game ->
+
+            DetailBody(
+                game = game,
+                viewModel = viewModel,
+                savedState = savedState,
+                context = context
+            )
+
+            state.shareSheetGame?.let {
+                context.shareLink("Check out this ${game.name} game on Gamex!")
+                viewModel.eventHandler(ShareGame(dismissed = true))
+            }
+
+        } ?: run {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .shimmerEffect(),
+            )
+        }
+    }
+
+    LaunchEffectOnce {
+        viewModel.eventHandler(Init(game, navigator))
+    }
+}
+
+@Composable
+private fun DetailBody(
+    game: Game,
+    viewModel: DetailViewModel,
+    savedState: MutableState<Boolean>,
+    context: Context,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy((-30).dp),
+    ) {
+
+        GamePoster(
+            game = game,
+            onEvent = viewModel::eventHandler
+        )
+
+        DetailsContent(
+            game = game,
+            savedState = savedState,
+            viewModel = viewModel,
+            context = context
+        )
+    }
+}
+
+@Composable
+private fun DetailsContent(
+    game: Game,
+    savedState: MutableState<Boolean>,
+    viewModel: DetailViewModel,
+    context: Context,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
+            .background(Color.White)
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+
+        DetailTitle(
+            game = game,
+            savedState = savedState,
+            viewModel = viewModel,
+            context = context
+        )
+
+        GeneralGameInfo(game = game)
+
+        Gap(size = 16.dp)
+
+        Text(
+            text = stringResource(R.string.copy_description),
+            style = MaterialTheme.typography.titleMedium,
+            color = Primary70
+        )
+
+        Text(
+            text = game.description.ifBlank { "-" },
+            style = MaterialTheme.typography.labelSmall,
+            color = Neutral50,
+        )
+
+        Gap(size = 16.dp)
+
+        Screenshots(urls = game.shortScreenshots)
+
+        if (game.tags.isNotEmpty()) {
+            Tags(game)
+        }
+    }
+}
+
+@Composable
+private fun DetailTitle(
+    game: Game,
+    savedState: MutableState<Boolean>,
+    viewModel: DetailViewModel,
+    context: Context,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+
+        Text(
+            text = game.name,
+            style = MaterialTheme.typography.titleLarge,
+            color = Primary70,
+            modifier = Modifier.weight(1F)
+        )
+
+        Icon(
+            imageVector = if (savedState.value) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
+            contentDescription = null,
+            tint = Primary70,
+            modifier = Modifier
+                .size(32.dp)
+                .padding(top = 4.dp)
+                .clickable {
+                    savedState.value = !savedState.value
+                    viewModel.eventHandler(
+                        BookmarkGame(
+                            id = game.id,
+                            bookmarked = savedState.value
+                        )
+                    )
+                    if (savedState.value) context.showToast("Bookmarked!")
+                }
+
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.Tags(game: Game) {
+    Gap(size = 16.dp)
+    Text(
+        text = "Tag",
+        style = MaterialTheme.typography.bodyMedium,
+        color = Neutral40
+    )
+    TagGroup(tag = game.tags.take(8))
 }

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/DetailScreenEvent.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/DetailScreenEvent.kt
@@ -1,0 +1,30 @@
+package com.repleyva.gamexapp.presentation.screens.detail
+
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import com.repleyva.core.domain.model.Game
+import com.repleyva.gamexapp.presentation.base.Event
+
+sealed interface DetailScreenEvent : Event {
+
+    data class Init(
+        val game: Game,
+        val navigator: DestinationsNavigator,
+    ) : DetailScreenEvent
+
+    data object NavigateBack : DetailScreenEvent
+
+    data class BookmarkGame(
+        val id: Long,
+        val bookmarked: Boolean,
+    ) : DetailScreenEvent
+
+    data class ShareGame(
+        val game: Game? = null,
+        val dismissed: Boolean = false,
+    ) : DetailScreenEvent
+
+    data class PlayTrailer(
+        val url: String,
+    ) : DetailScreenEvent
+
+}

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/DetailScreenState.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/DetailScreenState.kt
@@ -1,0 +1,12 @@
+package com.repleyva.gamexapp.presentation.screens.detail
+
+import com.repleyva.core.domain.model.Game
+import com.repleyva.gamexapp.presentation.base.State
+
+data class DetailScreenState(
+    val game: Game? = null,
+    val trailerUrl: String? = null,
+    val isLoading: Boolean = false,
+    val shareSheetGame: Game? = null,
+    val error: String? = null,
+) : State

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/DetailViewModel.kt
@@ -1,0 +1,108 @@
+package com.repleyva.gamexapp.presentation.screens.detail
+
+import androidx.lifecycle.viewModelScope
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import com.repleyva.core.domain.model.Game
+import com.repleyva.core.domain.use_cases.GameUseCase
+import com.repleyva.core.domain.vo.Resource.Error
+import com.repleyva.core.domain.vo.Resource.Loading
+import com.repleyva.core.domain.vo.Resource.Success
+import com.repleyva.gamexapp.presentation.base.SimpleMVIBaseViewModel
+import com.repleyva.gamexapp.presentation.screens.destinations.VideoPlayerDestination
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.BookmarkGame
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.Init
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.NavigateBack
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.PlayTrailer
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.ShareGame
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DetailViewModel @Inject constructor(
+    private val gameUseCase: GameUseCase,
+) : SimpleMVIBaseViewModel<DetailScreenState, DetailScreenEvent>() {
+
+    private var navigator: DestinationsNavigator? = null
+
+    override fun initState(): DetailScreenState = DetailScreenState()
+
+    override fun eventHandler(event: DetailScreenEvent) {
+        when (event) {
+            is Init -> init(event.game, event.navigator)
+            is NavigateBack -> navigateBack()
+            is BookmarkGame -> setBookmarked(event.id, event.bookmarked)
+            is ShareGame -> shareGame(event.game, event.dismissed)
+            is PlayTrailer -> playTrailer(event.url)
+        }
+    }
+
+    private fun init(
+        game: Game,
+        navigator: DestinationsNavigator,
+    ) {
+        this.navigator = navigator
+        updateUi { copy(game = game) }
+        viewModelScope.launch {
+            fetchDetailGame(game.id)
+            fetchGameTrailer(game.id)
+        }
+    }
+
+    private fun fetchDetailGame(gameId: Long) {
+        viewModelScope.launch(Dispatchers.IO) {
+            gameUseCase.getGameDetails(gameId).onEach { result ->
+                updateUi {
+                    when (result) {
+                        is Error -> copy(isLoading = false, error = result.message)
+                        is Loading -> copy(isLoading = true)
+                        is Success -> copy(game = result.data, isLoading = false, error = null)
+
+                    }
+                }
+            }.launchIn(viewModelScope)
+        }
+    }
+
+    private fun fetchGameTrailer(gameId: Long) {
+        viewModelScope.launch(Dispatchers.IO) {
+            gameUseCase.fetchGameTrailer(gameId).onEach { result ->
+                updateUi {
+                    when (result) {
+                        is Error -> copy(isLoading = false, error = result.message)
+                        is Loading -> copy(isLoading = true)
+                        is Success -> this
+                    }
+                }
+            }.launchIn(viewModelScope)
+        }
+    }
+
+    private fun shareGame(
+        game: Game?,
+        isDismissed: Boolean,
+    ) {
+        updateUi { copy(shareSheetGame = if (isDismissed) null else game) }
+    }
+
+    private fun setBookmarked(
+        id: Long,
+        isBookmarked: Boolean,
+    ) {
+        viewModelScope.launch {
+            gameUseCase.setIsFavorites(isBookmarked, id)
+        }
+    }
+
+    private fun playTrailer(url: String) {
+        navigator?.navigate(VideoPlayerDestination(url))
+    }
+
+    private fun navigateBack() {
+        navigator?.popBackStack()
+    }
+
+}

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/GamePoster.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/GamePoster.kt
@@ -1,0 +1,149 @@
+package com.repleyva.gamexapp.presentation.screens.detail.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.repleyva.core.domain.model.Game
+import com.repleyva.gamexapp.R
+import com.repleyva.gamexapp.presentation.components.CoilImage
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent
+import com.repleyva.gamexapp.presentation.ui.theme.Primary70
+
+@Composable
+fun GamePoster(
+    game: Game,
+    modifier: Modifier = Modifier,
+    onEvent: (DetailScreenEvent) -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(300.dp)
+    ) {
+
+        CoilImage(
+            url = game.backgroundImage,
+            modifier = Modifier.fillMaxSize()
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.2F))
+        )
+
+        TopBar(
+            onEvent = onEvent,
+            game = game
+        )
+
+        if (!game.trailerUrl.isNullOrEmpty()) {
+            ActionPlayTrailer(
+                game = game,
+                onEvent = onEvent,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+    }
+}
+
+@Composable
+private fun TopBar(
+    onEvent: (DetailScreenEvent) -> Unit,
+    game: Game,
+) {
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 24.dp, vertical = 18.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+
+        Icon(
+            imageVector = Icons.Default.ArrowBack,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier
+                .size(24.dp)
+                .clickable {
+                    onEvent(DetailScreenEvent.NavigateBack)
+                }
+        )
+
+        Icon(
+            imageVector = Icons.Default.Share,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier
+                .size(24.dp)
+                .clickable {
+                    onEvent(DetailScreenEvent.ShareGame(game))
+                }
+        )
+    }
+}
+
+@Composable
+private fun ActionPlayTrailer(
+    modifier: Modifier,
+    game: Game,
+    onEvent: (DetailScreenEvent) -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+
+        Box(
+            modifier = Modifier
+                .size(50.dp)
+                .background(Color.White, CircleShape)
+                .clickable {
+                    game.trailerUrl?.let {
+                        onEvent(DetailScreenEvent.PlayTrailer(it))
+                    }
+                }
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_play),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(Primary70),
+                modifier = Modifier
+                    .size(24.dp)
+                    .align(Alignment.Center)
+            )
+        }
+
+        Text(
+            text = stringResource(id = R.string.action_play_trailer),
+            style = MaterialTheme.typography.titleSmall,
+            color = Color.White
+        )
+    }
+}

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/GeneralGameInfo.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/GeneralGameInfo.kt
@@ -1,0 +1,139 @@
+package com.repleyva.gamexapp.presentation.screens.detail.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.repleyva.core.domain.enums.ConverterDate
+import com.repleyva.core.domain.extensions.convertDateTo
+import com.repleyva.core.domain.model.Game
+import com.repleyva.gamexapp.R
+import com.repleyva.gamexapp.presentation.screens.home.components.RatingBar
+import com.repleyva.gamexapp.presentation.screens.home.components.TagGroup
+import com.repleyva.gamexapp.presentation.ui.theme.Accent10
+import com.repleyva.gamexapp.presentation.ui.theme.Accent50
+import com.repleyva.gamexapp.presentation.ui.theme.Neutral40
+import com.repleyva.gamexapp.presentation.ui.theme.Neutral50
+
+@Composable
+fun GeneralGameInfo(
+    game: Game,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        TopDetailsGame(game)
+        GameInformation(game)
+    }
+}
+
+@Composable
+private fun TopDetailsGame(game: Game) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(36.dp)
+    ) {
+        MetaScoreInformation(game)
+        RatingInformation(game)
+    }
+}
+
+@Composable
+private fun MetaScoreInformation(game: Game) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+
+        Text(
+            text = stringResource(R.string.copy_metascore),
+            style = MaterialTheme.typography.bodyMedium,
+            color = Neutral40
+        )
+
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(Accent10)
+        ) {
+            Text(
+                text = if (game.metacritic != 0) game.metacritic.toString() else "-",
+                style = MaterialTheme.typography.titleSmall,
+                color = Accent50,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+    }
+}
+
+@Composable
+private fun RatingInformation(game: Game) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = stringResource(R.string.copy_rating),
+            style = MaterialTheme.typography.bodyMedium,
+            color = Neutral40
+        )
+        RatingBar(
+            rating = game.rating.toFloat(),
+            modifier = Modifier
+                .height(16.dp)
+        )
+    }
+}
+
+@Composable
+private fun GameInformation(game: Game) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(40.dp)
+    ) {
+        ReleasedInformation(game)
+        GenreInformation(game)
+    }
+}
+
+@Composable
+private fun ReleasedInformation(game: Game) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+
+        Text(
+            text = stringResource(R.string.copy_released),
+            style = MaterialTheme.typography.bodyMedium,
+            color = Neutral40
+        )
+        Text(
+            text = game.released.convertDateTo(ConverterDate.FULL_DATE),
+            style = MaterialTheme.typography.bodyMedium,
+            color = Neutral50
+        )
+    }
+}
+
+@Composable
+private fun GenreInformation(game: Game) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.copy_genre),
+            style = MaterialTheme.typography.bodyMedium,
+            color = Neutral40
+        )
+        TagGroup(tag = game.genres)
+    }
+}

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/Screenshots.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/Screenshots.kt
@@ -1,0 +1,51 @@
+package com.repleyva.gamexapp.presentation.screens.detail.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.repleyva.gamexapp.R
+import com.repleyva.gamexapp.presentation.components.CoilImage
+import com.repleyva.gamexapp.presentation.ui.theme.Primary70
+
+@Composable
+fun Screenshots(
+    urls: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+
+        Text(
+            text = stringResource(R.string.copy_screenshots),
+            style = MaterialTheme.typography.titleMedium,
+            color = Primary70
+        )
+
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            items(
+                items = urls,
+                key = { it }
+            ) {
+                CoilImage(
+                    url = it,
+                    modifier = Modifier
+                        .fillParentMaxWidth()
+                        .height(200.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/video_player/VideoPlayer.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/video_player/VideoPlayer.kt
@@ -1,0 +1,10 @@
+package com.repleyva.gamexapp.presentation.screens.video_player
+
+import androidx.compose.runtime.Composable
+import com.ramcosta.composedestinations.annotation.Destination
+
+@Destination
+@Composable
+fun VideoPlayer(url: String) {
+
+}

--- a/app/src/main/res/drawable/ic_play.xml
+++ b/app/src/main/res/drawable/ic_play.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19.342,13.131L8.142,19.798C7.915,19.932 7.658,20 7.4,20C7.167,20 6.933,19.945 6.721,19.833C6.276,19.598 6,19.152 6,18.667V5.334C6,4.849 6.276,4.403 6.721,4.168C7.166,3.932 7.71,3.946 8.142,4.203L19.342,10.87C19.751,11.114 20,11.541 20,12C20,12.46 19.751,12.887 19.342,13.131Z"
+      android:fillColor="#110E47"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,10 @@
     <string name="copy_hot_games">Hot Games</string>
     <string name="copy_app_description">Largest Game Database</string>
     <string name="copy_see_more">See more</string>
+    <string name="copy_screenshots">Screenshots</string>
+    <string name="copy_rating">Rating</string>
+    <string name="copy_genre">Genre</string>
+    <string name="copy_released">Released</string>
+    <string name="copy_metascore">Metascore</string>
+    <string name="copy_description">Description</string>
 </resources>


### PR DESCRIPTION
This commit introduces the detail screen, including:

-   **Context Extensions:** Added `showToast` and `shareLink` extension functions for `Context`.
-   **Screenshots Component:** Created a `Screenshots` composable to display a list of image URLs in a horizontal scrollable row.
-   **Detail ViewModel:** Implemented `DetailViewModel` to manage the state and events of the detail screen. This includes fetching game details and trailers, handling bookmarking, sharing, and playing trailers.
-   **Game Poster Component:** Created a `GamePoster` composable to display the game's poster image, including a play trailer button and share.
-   **Play Icon:** Added an `ic_play` vector drawable for the play trailer button.
-   **Detail Screen State:** Created `DetailScreenState` to hold the data and UI state for the detail screen.
-   **Detail Screen:** Implemented `DetailScreen`, which fetches and displays detailed game information, screenshots, and other game info.
-   **Detail Screen Event:** Defined `DetailScreenEvent` as a sealed interface for all events that can occur on the detail screen.
-   **General Game Info:** Created `GeneralGameInfo` to show general information about the game.
-   **String Resources:** Added string resources for new UI elements and text.
-   **Video Player Screen:** Created an empty `VideoPlayer` screen.