### PR TITLE
feat: Add detail screen UI tests and improve detail screen components

### DIFF
--- a/app/src/androidTest/java/com/repleyva/gamexapp/presentation/DetailScreenTest.kt
+++ b/app/src/androidTest/java/com/repleyva/gamexapp/presentation/DetailScreenTest.kt
@@ -1,0 +1,288 @@
+package com.repleyva.gamexapp.presentation
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.repleyva.core.domain.constants.Constants.dummyGame
+import com.repleyva.core.domain.enums.ConverterDate
+import com.repleyva.core.domain.extensions.convertDateTo
+import com.repleyva.gamexapp.R
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreen
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.BookmarkGame
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent.ShareGame
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenState
+import com.repleyva.gamexapp.presentation.ui.theme.GamexAppTheme
+import org.junit.Rule
+import org.junit.Test
+
+class DetailScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun verify_ShareButton_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = { assert(it is ShareGame) }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("shareButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("shareButton").performClick()
+    }
+
+    @Test
+    fun verify_OnBackPress_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = { assert(true) },
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("backButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("backButton").performClick()
+    }
+
+    @Test
+    fun verify_Image_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("backgroundImage").assertIsDisplayed()
+    }
+
+    @Test
+    fun verify_TrailerButton_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = { assert(true) },
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("playTrailerButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("playTrailerButton").performClick()
+    }
+
+    @Test
+    fun verify_Title_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+
+        }
+
+        composeTestRule.onNodeWithText(sampleGame.name).assertIsDisplayed()
+    }
+
+    @Test
+    fun verify_SaveButton_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = { assert(it is BookmarkGame && it.bookmarked) }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("saveButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("saveButton").performClick()
+    }
+
+    @Test
+    fun verify_GeneralInfo_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("generalInfo").assertIsDisplayed()
+    }
+
+    @Test
+    fun verify_MetaScore_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.copy_metascore)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(sampleGame.metacritic.toString()).assertIsDisplayed()
+    }
+
+    @Test
+    fun verify_Rating_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.copy_rating)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("ratingBar").assertIsDisplayed()
+    }
+
+    @Test
+    fun verify_Released_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.copy_released)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(sampleGame.released.convertDateTo(ConverterDate.FULL_DATE)).assertIsDisplayed()
+    }
+
+    @Test
+    fun verify_Genre_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+
+        composeTestRule.onNodeWithText(context.getString(R.string.copy_genre)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("genres").assertIsDisplayed()
+    }
+
+    @Test
+    fun verify_Description_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.copy_description)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(sampleGame.description.ifBlank { "-" }).assertIsDisplayed()
+    }
+
+    @Test
+    fun verify_Screenshots_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.copy_screenshots)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("screenshots").assertIsDisplayed()
+    }
+
+    @Test
+    fun verify_Tags_inDetailScreen() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                DetailScreen(
+                    state = DetailScreenState(game = sampleGame),
+                    game = sampleGame,
+                    onPlayTrailer = {},
+                    onNavigateBack = {},
+                    eventHandler = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.copy_tags)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("tags").assertIsDisplayed()
+    }
+
+    private val sampleGame = dummyGame.copy(
+        id = 1000L,
+        name = "Game 1",
+        backgroundImage = "backgroundImage",
+        trailerUrl = "trailerUrl",
+        tags = listOf("Tag 1", "Tag 2"),
+        genres = listOf("Genre 1", "Genre 2"),
+        shortScreenshots = listOf("screenshot1", "screenshot2"),
+    )
+}

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/nav/GamexNavGraph.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/nav/GamexNavGraph.kt
@@ -19,6 +19,7 @@ import com.repleyva.gamexapp.presentation.screens.bookmark.BookmarkScreen
 import com.repleyva.gamexapp.presentation.screens.bookmark.BookmarkScreenEvent.Init
 import com.repleyva.gamexapp.presentation.screens.bookmark.BookmarkViewModel
 import com.repleyva.gamexapp.presentation.screens.detail.DetailScreen
+import com.repleyva.gamexapp.presentation.screens.detail.DetailScreenEvent
 import com.repleyva.gamexapp.presentation.screens.detail.DetailViewModel
 import com.repleyva.gamexapp.presentation.screens.home.HomeScreen
 import com.repleyva.gamexapp.presentation.screens.home.HomeViewModel
@@ -47,11 +48,20 @@ fun GamexNavGraph(
         }
 
         composable<DetailScreen> {
-            val detailViewModel = hiltViewModel<DetailViewModel>()
+
             navController.previousBackStackEntry?.savedStateHandle?.get<Game>("game")?.let {
+
+                val viewModel = hiltViewModel<DetailViewModel>()
+                val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+                LaunchEffectOnce {
+                    viewModel.eventHandler(DetailScreenEvent.Init(it))
+                }
+
                 DetailScreen(
+                    state = state,
                     game = it,
-                    viewModel = detailViewModel,
+                    eventHandler = viewModel::eventHandler,
                     onNavigateBack = {
                         navController.popBackStack()
                         navController.currentBackStackEntry?.savedStateHandle?.remove<Game>("game")

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/GamePoster.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/GamePoster.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -48,7 +49,9 @@ fun GamePoster(
 
         CoilImage(
             url = game.backgroundImage,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("backgroundImage")
         )
 
         Box(
@@ -67,7 +70,9 @@ fun GamePoster(
             ActionPlayTrailer(
                 game = game,
                 onPlayTrailer = onPlayTrailer,
-                modifier = Modifier.align(Alignment.Center)
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .testTag("playTrailerButton")
             )
         }
     }
@@ -92,6 +97,7 @@ private fun TopBar(
             contentDescription = null,
             tint = Color.White,
             modifier = Modifier
+                .testTag("backButton")
                 .size(24.dp)
                 .clickable {
                     onNavigateBack()
@@ -103,6 +109,7 @@ private fun TopBar(
             contentDescription = null,
             tint = Color.White,
             modifier = Modifier
+                .testTag("shareButton")
                 .size(24.dp)
                 .clickable {
                     onShareGame(game)

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/GeneralGameInfo.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/GeneralGameInfo.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.repleyva.core.domain.enums.ConverterDate
@@ -34,7 +35,7 @@ fun GeneralGameInfo(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
+        modifier = modifier.testTag("generalInfo"),
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
         TopDetailsGame(game)
@@ -91,6 +92,7 @@ private fun RatingInformation(game: Game) {
             rating = game.rating.toFloat(),
             modifier = Modifier
                 .height(16.dp)
+                .testTag("ratingBar")
         )
     }
 }
@@ -134,6 +136,9 @@ private fun GenreInformation(game: Game) {
             style = MaterialTheme.typography.bodyMedium,
             color = Neutral40
         )
-        TagGroup(tag = game.genres)
+        TagGroup(
+            modifier = Modifier.testTag("genres"),
+            tag = game.genres
+        )
     }
 }

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/Screenshots.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/detail/components/Screenshots.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.repleyva.gamexapp.R
@@ -33,7 +34,9 @@ fun Screenshots(
         )
 
         LazyRow(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("screenshots")
         ) {
             items(
                 items = urls,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="copy_description">Description</string>
     <string name="copy_search_title">What games are you looking for?</string>
     <string name="copy_search_placeholder">Search...</string>
+    <string name="copy_tags">Tags</string>
 </resources>

--- a/core/src/main/java/com/repleyva/core/domain/constants/Constants.kt
+++ b/core/src/main/java/com/repleyva/core/domain/constants/Constants.kt
@@ -16,7 +16,7 @@ object Constants {
         ratingsCount = 0,
         reviewsTextCount = 0,
         added = 0,
-        metacritic = 0,
+        metacritic = 10,
         playtime = 0,
         suggestionsCount = 0,
         updated = "updated",


### PR DESCRIPTION
This commit introduces UI tests for the detail screen and improves the detail screen components.

- Added UI tests for the DetailScreen to verify the functionality and display of its components (e.g., share button, back button, image, trailer button, title, save button, general info, meta score, rating, released date, genre, description, screenshots, tags).
- Added test tags to `GamePoster`, `GeneralGameInfo`, `Screenshots` and `TagGroup` composables for UI testing.
- Add `metacritic` field to `dummyGame` in `Constants` and set it to 10.
- Updated DetailScreen to use DetailScreenState for managing the UI state.
- Update to  `DetailScreen` to use event handler
- Added new strings for `tags`.