### PR TITLE
feat: Add search screen UI tests and update search screen composable

### DIFF
--- a/app/src/androidTest/java/com/repleyva/gamexapp/presentation/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/repleyva/gamexapp/presentation/SearchScreenTest.kt
@@ -1,0 +1,172 @@
+package com.repleyva.gamexapp.presentation
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.performTextInput
+import androidx.test.platform.app.InstrumentationRegistry
+import com.repleyva.core.domain.constants.Constants.dummyGame
+import com.repleyva.gamexapp.R
+import com.repleyva.gamexapp.presentation.screens.search.SearchScreen
+import com.repleyva.gamexapp.presentation.screens.search.SearchScreenEvent.OnSearchQueryChange
+import com.repleyva.gamexapp.presentation.screens.search.SearchScreenState
+import com.repleyva.gamexapp.presentation.ui.theme.GamexAppTheme
+import org.junit.Rule
+import org.junit.Test
+
+class SearchScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun verifySearchTitle_displayed() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                SearchScreen(
+                    state = SearchScreenState(),
+                    eventHandler = {},
+                    onDetailScreen = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.copy_search_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun verifySearchPlaceholder_displayed() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                SearchScreen(
+                    state = SearchScreenState(),
+                    eventHandler = {},
+                    onDetailScreen = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.copy_search_placeholder)).assertIsDisplayed()
+    }
+
+    @Test
+    fun verifySearchIcon_displayed() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                SearchScreen(
+                    state = SearchScreenState(),
+                    eventHandler = {},
+                    onDetailScreen = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("searchIcon").assertIsDisplayed()
+    }
+
+    @Test
+    fun verifySendIcon_displayed() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                SearchScreen(
+                    state = SearchScreenState(),
+                    eventHandler = {},
+                    onDetailScreen = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("sendIcon").assertIsDisplayed()
+    }
+
+    @Test
+    fun verifyPlaceholder_whenQuery_inNotEmpty() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                SearchScreen(
+                    state = SearchScreenState(),
+                    eventHandler = { assert(it is OnSearchQueryChange) },
+                    onDetailScreen = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("searchInput").performTextInput("test")
+        composeTestRule.onNodeWithTag("placeholderText").assertDoesNotExist()
+    }
+
+    @Test
+    fun verifySearchResults_displayed() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                SearchScreen(
+                    state = SearchScreenState(games = sampleGames),
+                    eventHandler = {},
+                    onDetailScreen = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(sampleGames[0].name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(sampleGames[1].name).assertIsDisplayed()
+    }
+
+    @Test
+    fun verifySearchResults_whenGameIsClicked() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                SearchScreen(
+                    state = SearchScreenState(games = sampleGames),
+                    eventHandler = {},
+                    onDetailScreen = { assert(it == sampleGames[0]) }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(sampleGames[0].name).performClick()
+    }
+
+    @Test
+    fun verifySearchResults_whenListIsLarge() {
+        composeTestRule.setContent {
+            GamexAppTheme {
+                SearchScreen(
+                    state = SearchScreenState(games = sampleLargeGames),
+                    eventHandler = {},
+                    onDetailScreen = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(sampleLargeGames[0].name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(sampleLargeGames[1].name).assertIsDisplayed()
+        composeTestRule.onNodeWithTag("searchResultList").performScrollToIndex(sampleLargeGames.lastIndex)
+        composeTestRule.onNodeWithText(sampleLargeGames[sampleLargeGames.lastIndex].name).assertIsDisplayed()
+    }
+
+    private val sampleGames = listOf(
+        dummyGame.copy(1000L, name = "Game 1"),
+        dummyGame.copy(1001L, name = "Game 2")
+    )
+
+    private val sampleLargeGames = listOf(
+        dummyGame.copy(1000L, name = "Game 1"),
+        dummyGame.copy(1001L, name = "Game 2"),
+        dummyGame.copy(1002L, name = "Game 3"),
+        dummyGame.copy(1003L, name = "Game 4"),
+        dummyGame.copy(1004L, name = "Game 5"),
+        dummyGame.copy(1005L, name = "Game 6"),
+        dummyGame.copy(1006L, name = "Game 7"),
+        dummyGame.copy(1007L, name = "Game 8"),
+        dummyGame.copy(1008L, name = "Game 9"),
+        dummyGame.copy(1009L, name = "Game 10"),
+        dummyGame.copy(1010L, name = "Game 11"),
+    )
+}

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/nav/GamexNavGraph.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/nav/GamexNavGraph.kt
@@ -77,8 +77,14 @@ fun GamexNavGraph(
         }
 
         composable<SearchScreen> {
+
             val searchViewModel = hiltViewModel<SearchViewModel>()
-            SearchScreen(searchViewModel) {
+            val state by searchViewModel.uiState.collectAsStateWithLifecycle()
+
+            SearchScreen(
+                state = state,
+                eventHandler = searchViewModel::eventHandler
+            ) {
                 navigateToDetails(
                     navController = navController,
                     game = it

--- a/app/src/main/java/com/repleyva/gamexapp/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/repleyva/gamexapp/presentation/screens/search/SearchScreen.kt
@@ -20,14 +20,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.repleyva.core.domain.model.Game
 import com.repleyva.gamexapp.R
 import com.repleyva.gamexapp.presentation.screens.home.components.GameItem
@@ -38,11 +37,10 @@ import com.repleyva.gamexapp.presentation.ui.theme.Primary50
 
 @Composable
 fun SearchScreen(
-    viewModel: SearchViewModel,
+    state: SearchScreenState,
+    eventHandler: (SearchScreenEvent) -> Unit,
     onDetailScreen: (game: Game) -> Unit,
 ) {
-
-    val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     Column(
         modifier = Modifier
@@ -61,7 +59,7 @@ fun SearchScreen(
 
         InputSearch(
             state = state,
-            viewModel = viewModel
+            eventHandler = eventHandler
         )
 
         SearchResults(
@@ -75,31 +73,32 @@ fun SearchScreen(
 @Composable
 private fun InputSearch(
     state: SearchScreenState,
-    viewModel: SearchViewModel,
+    eventHandler: (SearchScreenEvent) -> Unit,
 ) {
     TextField(
         value = state.query,
-        onValueChange = { viewModel.eventHandler(OnSearchQueryChange(it)) },
+        onValueChange = { eventHandler(OnSearchQueryChange(it)) },
         textStyle = MaterialTheme.typography.bodyLarge,
         placeholder = {
             Text(
                 text = stringResource(R.string.copy_search_placeholder),
                 color = Neutral40,
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.testTag("placeholderText")
             )
         },
         leadingIcon = {
             Image(
                 painter = painterResource(id = R.drawable.ic_search),
-                contentDescription = null,
+                contentDescription = "searchIcon",
                 modifier = Modifier.size(32.dp)
             )
         },
         trailingIcon = {
             Icon(
                 imageVector = Icons.Default.Send,
-                contentDescription = null,
-                tint = Primary50
+                contentDescription = "sendIcon",
+                tint = Primary50,
             )
         },
         colors = TextFieldDefaults.colors(
@@ -116,6 +115,7 @@ private fun InputSearch(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
+            .testTag("searchInput")
     )
 }
 
@@ -125,7 +125,9 @@ private fun SearchResults(
     onDetailScreen: (game: Game) -> Unit,
 ) {
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("searchResultList"),
         contentPadding = PaddingValues(vertical = 24.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {


### PR DESCRIPTION
This commit introduces UI tests for the `SearchScreen` composable and updates its implementation.

- Added UI tests for `SearchScreen` to verify the title, placeholder, icons, and search results.
- Created `SearchScreenTest` to test the UI components and their behavior.
- Added `testTag`s for `placeholderText`, `searchInput`, and `searchResultList` to support testing.
- Updated `SearchScreen` composable to use `state` and `eventHandler` instead of `ViewModel`.
- Updated `GamexNavGraph` to pass `state` and `eventHandler` to `SearchScreen`.
- Add `dummyGame` and `Constants`
- Remove unused `getValue` in SearchScreen.kt